### PR TITLE
Add dependency to mruby-metaprog following current mruby usage

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,5 +5,6 @@ MRuby::Gem::Specification.new('mruby-forwardable') do |spec|
   spec.version = '0.1.0'
 
   spec.add_dependency 'mruby-array-ext', core: 'mruby-array-ext'
+  spec.add_dependency 'mruby-metaprog', core: 'mruby-metaprog'
   spec.add_dependency 'mruby-onig-regexp', mgem: 'mruby-onig-regexp'
 end


### PR DESCRIPTION
Many of metaprogramming features are now splited into core mgem. e.g. `Object#send`, `Object#instance_eval`, ...